### PR TITLE
chore: simplify an example of diff checking

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+          if ! git diff --ignore-space-at-eol --exit-code --quiet dist/; then
             echo "Detected uncommitted changes after build.  See status below:"
             git diff
             exit 1

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ steps:
   - name: Verify generated types match Postgres schema
     run: |
       supabase gen types typescript --local > schema.gen.ts
-      if [ "$(git diff --ignore-space-at-eol schema.gen.ts | wc -l)" -gt "0" ]; then
+      if ! git diff --ignore-space-at-eol --exit-code --quiet schema.gen.ts; then
         echo "Detected uncommitted changes after build. See status below:"
         git diff
         exit 1


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs 

## Additional context

The original sample hides the result of `git diff`. So if `git diff` returns an error(e.g. invalid file name specified), the result will be success.

We can use `--exit-code ` option if we only want to know whether differences exist without depending on other commands.
Ref: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---exit-code
