### PR TITLE
chore: use npm cache in check-dist.yml

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v3.6.0
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## What kind of change does this PR introduce?

Updated `check-dist.yml` to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data).

**AS-IS**

```yml
- name: Set up Node
  uses: actions/setup-node@v3.6.0
  with:
    node-version: 16.x
```

**TO-BE**

```yml
- name: Set up Node
  uses: actions/setup-node@v3.6.0
  with:
    node-version: 16.x
    cache: npm
```