### PR TITLE
Expose installed Supabase CLI version via output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: Version of Supabase CLI to install
     required: false
     default: 1.28.3
+outputs:
+  version:
+    description: Version of installed Supabase CLI
 runs:
   using: node16
   main: dist/index.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as tc from '@actions/tool-cache'
 import gte from 'semver/functions/gte'
-import {getDownloadUrl} from './utils'
+import {getDownloadUrl, determineInstalledVersion} from './utils'
 
 export const CLI_CONFIG_REGISTRY = 'SUPABASE_INTERNAL_IMAGE_REGISTRY'
 
@@ -19,6 +19,10 @@ async function run(): Promise<void> {
 
     // Expose the tool by adding it to the PATH
     core.addPath(pathToCLI)
+
+    // Expose installed tool version
+    const determinedVersion = await determineInstalledVersion()
+    core.setOutput('version', determinedVersion)
 
     // Use GHCR mirror by default
     if (version.toLowerCase() === 'latest' || gte(version, '1.28.0')) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,9 @@
+import {exec} from 'child_process'
 import os from 'os'
 import lt from 'semver/functions/lt'
+import {promisify} from 'util'
+
+const doExec = promisify(exec)
 
 // arch in [arm, arm64, x64...] (https://nodejs.org/docs/latest-v16.x/api/os.html#osarch)
 // return value in [amd64, arm64, arm]
@@ -30,4 +34,15 @@ export const getDownloadUrl = async (version: string): Promise<string> => {
     return `https://github.com/supabase/cli/releases/download/v${version}/supabase_${version}_${platform}_${arch}.tar.gz`
   }
   return `https://github.com/supabase/cli/releases/download/v${version}/${filename}`
+}
+
+export const determineInstalledVersion = async (): Promise<string> => {
+  const {stdout} = await doExec('supabase --version')
+
+  const version = stdout.trim()
+  if (!version) {
+    throw new Error('Could not determine installed Supabase CLI version')
+  }
+
+  return version
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Expose installed Supabase CLI version via action output.

## What is the current behavior?

Installed CLI version is not available easily

## What is the new behavior?

Installed CLI version is exposed via action output

## Additional context

This is useful when setup-cli action is configured to install latest version, but following steps need to know what version was actually installed (for example, to implement Docker image caching to speed up test environment launching).

Will squash commits before merge.
