### PR TITLE
chore: update nodejs deprecated version to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ outputs:
   version:
     description: Version of installed Supabase CLI
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix: https://github.com/supabase/setup-cli/issues/255

Move from nodejs16 deprecated to 20

## What is the current behavior?

Trigger deprecated warning

## What is the new behavior?

Not trigger warning


