### PR TITLE
feat: bump default cli version to 1.178.2

### DIFF
--- a/.github/workflows/start.yml
+++ b/.github/workflows/start.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.176.10
+          - 1.178.2
           - latest
         pg_major:
           - 14

--- a/.github/workflows/start.yml
+++ b/.github/workflows/start.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.136.3
+          - 1.176.10
           - latest
         pg_major:
           - 14

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The actions supports the following inputs:
 
 | Name      | Type   | Description                        | Default   | Required |
 | --------- | ------ | ---------------------------------- | --------- | -------- |
-| `version` | String | Supabase CLI version (or `latest`) | `1.176.10` | false    |
+| `version` | String | Supabase CLI version (or `latest`) | `1.178.2` | false    |
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A specific version of the `supabase` CLI can be installed:
 steps:
   - uses: supabase/setup-cli@v1
     with:
-      version: 1.176.10
+      version: 1.178.2
 ```
 
 Run `supabase db start` to execute all migrations on a fresh database:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A specific version of the `supabase` CLI can be installed:
 steps:
   - uses: supabase/setup-cli@v1
     with:
-      version: 1.136.3
+      version: 1.176.10
 ```
 
 Run `supabase db start` to execute all migrations on a fresh database:
@@ -46,7 +46,7 @@ The actions supports the following inputs:
 
 | Name      | Type   | Description                        | Default   | Required |
 | --------- | ------ | ---------------------------------- | --------- | -------- |
-| `version` | String | Supabase CLI version (or `latest`) | `1.136.3` | false    |
+| `version` | String | Supabase CLI version (or `latest`) | `1.176.10` | false    |
 
 ## Advanced Usage
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: Version of Supabase CLI to install
     required: false
-    default: 1.136.3
+    default: 1.176.10
 outputs:
   version:
     description: Version of installed Supabase CLI

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: Version of Supabase CLI to install
     required: false
-    default: 1.176.10
+    default: 1.178.2
 outputs:
   version:
     description: Version of installed Supabase CLI


### PR DESCRIPTION
## What kind of change does this PR introduce?

update CLI version to 1.176.10 a la https://github.com/supabase/setup-cli/commit/87162dc7e9322b04c79bdb81e0dce1f261097ff2