### PR TITLE
fix: auto-approval and refine dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2
+      day: tuesday
+      time: "09:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 1
+    cooldown:
+      semver-minor-days: 7
+      semver-patch-days: 2
     groups:
-      actions-minor:
+      actions-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
@@ -15,15 +23,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2
+      day: tuesday
+      time: "09:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 1
+    cooldown:
+      semver-minor-days: 7
+      semver-patch-days: 2
     groups:
-      bun-development:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
-      bun-production:
-        dependency-type: production
+      bun-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -24,15 +24,23 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Generate token
+        id: app-token
+        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Approve a PR
-        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.meta.outputs.update-type == null || steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What changed

This updates our Dependabot policy to reduce routine dependency-update noise while keeping minor and patch updates moving automatically.

- Configure Dependabot to run weekly on Tuesday at 09:00 Europe/Paris for both `github-actions` and `bun`
- Group all minor and patch updates per ecosystem:
  - one GitHub Actions update PR
  - one Bun dependency update PR
- Keep major updates ungrouped so Dependabot opens individual PRs for manual review
- Reduce routine open Dependabot PRs to one per ecosystem
- Add cooldown windows so Dependabot avoids immediately chasing fresh releases:
  - 7 days for minor updates
  - 2 days for patch updates
- Update the Dependabot automerge workflow to generate a GitHub App token before approving PRs
- Auto-approve and enable automerge only for patch and minor updates, including `0.x` minors
- Leave major update PRs for human review and merge

## Why

Dependabot was not able to approve/automerge PRs using the default token. This follows the GitHub App token pattern recommended by security, while also tuning Dependabot for a better signal-to-noise ratio.

The resulting behavior is:

- minor/patch updates are batched weekly and can merge after CI passes
- major updates still appear, but individually and without automerge
- security updates remain handled by Dependabot/GitHub outside the routine grouping policy