### PR TITLE
[codex] fix dependabot actions cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       time: "09:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 1
-    cooldown:
-      semver-minor-days: 7
-      semver-patch-days: 2
     groups:
       actions-minor-patch:
         patterns:


### PR DESCRIPTION
## What changed

Remove the unsupported `cooldown.semver-minor-days` and `cooldown.semver-patch-days` settings from the `github-actions` Dependabot ecosystem.

The Bun ecosystem keeps its cooldown settings, and GitHub Actions updates keep the weekly Tuesday schedule, PR limit, and minor/patch grouping.

## Why

Dependabot rejects semver-specific cooldown properties for the `github-actions` ecosystem with:

```
The property `#/updates/0/cooldown/semver-minor-days` is not supported for the package ecosystem `github-actions`.
The property `#/updates/0/cooldown/semver-patch-days` is not supported for the package ecosystem `github-actions`.
```

Removing those keys restores a valid Dependabot config while preserving the grouped weekly update policy.

## Validation

- Parsed `.github/dependabot.yml` successfully as YAML
