### PR TITLE
fix: cache licensed action

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,6 +1,6 @@
-# This workflow checks the statuses of cached dependencies used in this action
-# with the help of the Licensed tool. If any licenses are invalid or missing,
-# this workflow will fail. See: https://github.com/licensee/licensed
+# This workflow refreshes and checks dependency license records used in this
+# action with the help of the Licensed tool. If any licenses are invalid or
+# missing, this workflow will fail. See: https://github.com/licensee/licensed
 
 name: Licensed
 
@@ -80,6 +80,11 @@ jobs:
         with:
           version: 4.x
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refresh License Cache
+        id: refresh-license-cache
+        if: steps.license-inputs.outputs.changed == 'true'
+        run: licensed cache
 
       - name: Check Licenses
         id: check-licenses


### PR DESCRIPTION
## Summary

Automate license cache refreshes during the Licensed CI check.

## Details

The Licensed workflow previously ran `licensed status` directly against the committed `.licenses` cache. Dependabot dependency bumps could fail when the cache was stale or missing records, even when the new dependency licenses were allowed.

This updates the check job to run `licensed cache` before `licensed status`, so CI refreshes dependency records in the ephemeral checkout before enforcing the license policy.

## Expected behavior

The Licensed workflow should now only fail when Licensed detects an invalid, missing, or disallowed license, not merely because committed cache records are stale.