### PR TITLE
docs: note latest release rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ If `version` is omitted, the action checks the repository root for `bun.lock`,
 `pnpm-lock.yaml`, or `package-lock.json` and uses the declared `supabase`
 version. If no supported lockfile is present, it falls back to `latest`.
 
+When the action resolves `latest`, it queries the GitHub releases API. In CI,
+pass `github-token: ${{ github.token }}` to avoid unauthenticated API rate
+limits. Pinning `version` to a specific Supabase CLI release avoids that lookup
+entirely.
+
 A specific version of the `supabase` CLI can be installed:
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add a README note explaining that resolving `latest` queries the GitHub releases API.
- Recommend passing `github-token: ${{ github.token }}` in CI to avoid unauthenticated API rate limits.
- Mention that pinning `version` avoids the release lookup entirely.

## Root Cause

Users who run the action with `version: latest`, or omit `version` without a supported root lockfile, can hit GitHub's unauthenticated REST API rate limit while the action resolves the latest Supabase CLI release.

## Validation

- Not run; README-only change.
